### PR TITLE
fix bug: memory access overrun in s2i_ASN1_INTEGER()

### DIFF
--- a/crypto/x509/v3_utl.c
+++ b/crypto/x509/v3_utl.c
@@ -216,11 +216,12 @@ ASN1_INTEGER *s2i_ASN1_INTEGER(X509V3_EXT_METHOD *method, const char *value)
         isneg = 0;
     }
 
-    if (value[0] == '0' && ((value[1] == 'x') || (value[1] == 'X'))) {
-        value += 2;
-        ishex = 1;
-    } else {
-        ishex = 0;
+    ishex = 0;
+    if (strlen(value) > 2) {
+        if (value[0] == '0' && ((value[1] == 'x') || (value[1] == 'X'))) {
+            value += 2;
+            ishex = 1;
+        }
     }
 
     if (ishex)


### PR DESCRIPTION
There is a bug here, when  a number '0' is passed in, the memory access is out of bounds.

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [ ] documentation is added or updated
- [ ] tests are added or updated
